### PR TITLE
New Spectral Function

### DIFF
--- a/pvl_FSspeccorr.m
+++ b/pvl_FSspeccorr.m
@@ -131,7 +131,7 @@ if ischar(varargin{1})
             % For modeling the performance of earlier CdTe module series,
             % use the coefficients that are commented out
             % [0.79418,-0.049883,-0.013402,0.16766,0.083377,-0.0044007];
-             coeff = [0.86273,	-0.038948, -0.012506, 0.098871, 0.084658 -0.0042948];
+             coeff = [0.86273, -0.038948, -0.012506, 0.098871, 0.084658, -0.0042948];
         case {'monosi','xsi'}
             % Coefficients for First Solar TetraSun Modules
              coeff = [0.85914, -0.020880, -0.0058853, 0.12029, 0.026814, -0.0017810];

--- a/pvl_FSspeccorr.m
+++ b/pvl_FSspeccorr.m
@@ -79,6 +79,48 @@ function [M] = pvl_FSspeccorr(Pwat,AMa,varargin)
 
 
 
+% Correct for AMa and Pwat having transposed dimensions 
+if isrow(AMa)
+    AMa = AMa';
+end
+
+if isrow(Pwat)
+    Pwat = Pwat';
+end
+
+% --- Screen Input Data ---
+
+% *** Pwat ***
+% Replace Pwat Values below 0.1 cm with 0.1 cm to prevent model from
+% diverging
+if min(Pwat) < 0.1
+    Pwat(Pwat < 0.1) = 0.1;
+    warning(['Exceptionally low Pwat values replaced with 0.1 cm to prevent',...
+        ' model divergence']);
+end
+
+% Warn user about Pwat data that is exceptionally high
+if max(Pwat) > 8
+    warning(['Exceptionally high Pwat values. Check input data:', ...
+        ' model may diverge in this range']);
+end
+
+% *** AMa ***
+% Replace Extremely High AM with AM 10 to prevent model divergence
+% AM > 10 will only occur very close to sunset
+if max(AMa) > 10 
+  AMa(AMa > 10) = 10;
+end
+
+% Warn user about AMa data that is exceptionally low
+if min(AMa) < 0.58
+   warning(['Exceptionally low air mass: ',...
+       'model not intended for extra-terrestrial use'])
+   % pvl_absoluteairmass(1,pvl_alt2pres(4340)) = 0.58
+   % Elevation of Mina Pirquita, Argentian = 4340 m. Highest elevation city
+   % with population over 50,000.
+end
+
 % If user input is a character array, use appropriate default coefficients.
 if ischar(varargin{1})
     modType = lower(varargin{1});
@@ -102,15 +144,6 @@ if ischar(varargin{1})
 % User input coefficients    
 else
     coeff = varargin{1};
-end
-
-% Correct for AMa and Pwat having transposed dimensions 
-if isrow(AMa)
-    AMa = AMa';
-end
-
-if isrow(Pwat)
-    Pwat = Pwat';
 end
 
 % Evaluate Spectral Shift

--- a/pvl_FSspeccorr.m
+++ b/pvl_FSspeccorr.m
@@ -14,15 +14,15 @@ function [M] = pvl_FSspeccorr(Pwat,AMa,varargin)
 %   precipitable water, Pwat, using the following function:
 %
 %   M = coeff(1) + coeff(2)*AMa  + coeff(3)*Pwat  + coeff(4)*AMa.^.5  
-%           + coeff(5)*Pwat.^.5 + coeff(6)*AMa./Pwat                    (1) 
+%           + coeff(5)*Pwat.^.5 + coeff(6)*AMa./Pwat.^0.5         (1) 
 %
 %   Default coefficients are determined for several cell types with 
 %   known quantum efficiency curves, by using the Simple Model of the 
 %   Atmospheric Radiative Transfer of Sunshine (SMARTS) [1]. 
 %   Using SMARTS, spectrums are simulated with all combinations of AMa 
 %   and Pwat where:
-%       *   0.5 cm <= Pwat <= 5 cm
-%       *   0.8 <= AMa <= 4.75 (Pressure of 800 mbar and 1.01 <= AM <= 6)
+%       *   0.1 cm <= Pwat <= 5 cm
+%       *   1.0 <= AMa <= 5 
 %       *   Spectral range is limited to that of CMP11 (280 nm to 2800 nm)
 %       *   spectrum simulated on a plane normal to the sun
 %       *   All other parameters fixed at G173 standard
@@ -31,7 +31,8 @@ function [M] = pvl_FSspeccorr(Pwat,AMa,varargin)
 %   Eq. 1 to determine the coefficients for each module.
 %
 %  Function pvl_FSspeccorr was developed by Mitchell Lee and Alex Panchula,
-%   at First Solar, 2015.
+%   at First Solar, 2015. Detailed description of spectral correction 
+%   can be found in [2] 
 %
 % Inputs:
 %   Pwat - atmospheric precipitable water (cm). Can be
@@ -47,7 +48,7 @@ function [M] = pvl_FSspeccorr(Pwat,AMa,varargin)
 %           'multisi','polysi' - coefficients for multi-crystalline silicon 
 %               modules. The module used to calculate the spectral
 %               correction coefficients corresponds to the Mult-crystalline 
-%               silicon Manufacturer 2 Model C from [2].
+%               silicon Manufacturer 2 Model C from [3].
 %   custCoeff - allows for entry of user defined spectral correction
 %       coefficients. Coefficients must be entered as a numeric row or 
 %       column vector of length 6. Derivation of coefficients requires use 
@@ -69,7 +70,10 @@ function [M] = pvl_FSspeccorr(Pwat,AMa,varargin)
 % [1]   Gueymard, Christian. SMARTS2: a simple model of the atmospheric 
 %           radiative transfer of sunshine: algorithms and performance 
 %           assessment. Cocoa, FL: Florida Solar Energy Center, 1995.
-% [2]   Marion, William F., et al. User's Manual for Data for Validating 
+% [2]   Lee, Mitchell, and Panchula, Alex. "Spectral Correction for
+%           Photovoltaic Module Performance Based on Air Mass and Precipitable 
+%           Water." IEEE Photovoltaic Specialists Conference, Portland, 2016 
+% [3]   Marion, William F., et al. User's Manual for Data for Validating 
 %           Models for PV Module Performance. National Renewable Energy Laboratory, 2014.
 %           http://www.nrel.gov/docs/fy14osti/61610.pdf
 
@@ -84,14 +88,14 @@ if ischar(varargin{1})
             % Coefficients for First Solar Series 4-2 (and later) modules.
             % For modeling the performance of earlier CdTe module series,
             % use the coefficients that are commented out
-            %  [0.7900,	-0.0644, -0.01658,	0.1835, 0.09077, -0.002330];
-            coeff = [0.8752, -0.04588, -0.01559, 0.08751, 0.09158, -0.002295];
+            % [0.79418,-0.049883,-0.013402,0.16766,0.083377,-0.0044007];
+             coeff = [0.86273,	-0.038948, -0.012506, 0.098871, 0.084658 -0.0042948];
         case {'monosi','xsi'}
             % Coefficients for First Solar TetraSun Modules
-            coeff = [0.8478, -0.03326, -0.0022953, 0.1565, 0.01566, -0.001712];
+             coeff = [0.85914, -0.020880, -0.0058853, 0.12029, 0.026814, -0.0017810];
         case {'polysi','multisi'}
             % Coefficients for Multi-Si: Manufacturer 2 Model C
-            coeff = [0.83019, -0.04063,	-0.005281,	0.1695,	0.02974, -0.001676];
+            coeff = [0.84090, -0.027539, -0.0079224, 0.13570, 0.038024, -0.0021218];
         otherwise
             error('Incorrect module type for use of default parameters')
     end
@@ -110,6 +114,6 @@ if isrow(Pwat)
 end
 
 % Evaluate Spectral Shift
-M = coeff(1) + coeff(2)*AMa  + coeff(3)*Pwat  + coeff(4)*AMa.^.5  + coeff(5)*Pwat.^.5 + coeff(6)*AMa./Pwat; 
+M = coeff(1) + coeff(2)*AMa  + coeff(3)*Pwat  + coeff(4)*AMa.^.5  + coeff(5)*Pwat.^.5 + coeff(6)*AMa./Pwat.^0.5; 
 end
 

--- a/pvl_ephemeris.m
+++ b/pvl_ephemeris.m
@@ -1,4 +1,3 @@
-
 function [SunAz, SunEl, ApparentSunEl, SolarTime]= pvl_ephemeris(Time, Location, varargin)
 % PVL_EPHEMERIS Calculates the position of the sun given time, location, and optionally pressure and temperature
 %

--- a/pvl_ephemeris.m
+++ b/pvl_ephemeris.m
@@ -1,3 +1,4 @@
+
 function [SunAz, SunEl, ApparentSunEl, SolarTime]= pvl_ephemeris(Time, Location, varargin)
 % PVL_EPHEMERIS Calculates the position of the sun given time, location, and optionally pressure and temperature
 %


### PR DESCRIPTION
Updated spectral function "pvl_FSspeccorr.m" to reflect the functional form that was presented at IEEE PVSC43 with updated coefficients. I also added data flags/filters in order to make sure that the function doesn't "blow up" when given extraordinary inputs.

Minimum precipitable water floor is set to 0.1cm. This presents the function from going toward -Inf as precipitable water goes to toward zero.

An absolute airmass ceiling is placed at AM = 10. This prevents function from destabilizing at very high AM. AM > 10 occur very close to sunset/sunrise when irradiance levels are very low. 

Warning flags are now printed if Pwat is really high (above 8 cm), or if absolute air mass is very low (below .58)
